### PR TITLE
CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,13 @@ name: Release
 
 # Run by hand from the Actions tab. Building a release is cheap and repeatable; putting one in
 # front of the public is not, so this workflow stops at a tagged GitHub release with every
-# artifact attached. Only NuGet is pushed automatically - the Visual Studio, VS Code and JetBrains
-# listings are updated by uploading the attached files by hand.
+# artifact attached. Only NuGet is pushed automatically - the Visual Studio and VS Code listings
+# are updated by uploading the attached files by hand.
+#
+# The Rider plugin is deliberately not built here. Compiling against the Rider SDK costs a 3.6 GB
+# download that unpacks to 14 GB, which no cache on a hosted runner can hold, for an artifact that
+# has to be uploaded to the JetBrains Marketplace by hand anyway. It is built locally instead -
+# see editors/rider/README.md.
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +27,7 @@ permissions:
 
 jobs:
   # Decides which version this run produces, and refuses to start if that version has been
-  # released already. Every other job reads the answer from here, so all four artifacts carry the
+  # released already. Every other job reads the answer from here, so all artifacts carry the
   # same number.
   prepare:
     runs-on: ubuntu-latest
@@ -89,8 +94,8 @@ jobs:
             echo "- releasing: \`$publish\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Both packages are built at the same version, which also pins the LENS dependency that
-  # LENS.LanguageServer.Core takes on it.
+  # LENS is the only published package. Everything else in the repository is either an editor
+  # artifact or a project that only this repository references.
   nuget:
     needs: prepare
     runs-on: windows-latest
@@ -103,9 +108,7 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Pack
-        run: |
-          dotnet pack Lens/Lens.csproj --configuration Release -p:Version=${{ needs.prepare.outputs.version }} --output artifacts
-          dotnet pack Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj --configuration Release -p:Version=${{ needs.prepare.outputs.version }} --output artifacts
+        run: dotnet pack Lens/Lens.csproj --configuration Release -p:Version=${{ needs.prepare.outputs.version }} --output artifacts
 
       - uses: actions/upload-artifact@v4
         with:
@@ -169,7 +172,7 @@ jobs:
         shell: pwsh
         run: ./editors/vs/build.ps1
 
-      # the built file has no version in its name, and all four artifacts end up side by side on
+      # the built file has no version in its name, and all artifacts end up side by side on
       # the release page
       - name: Name the VSIX after the version
         shell: pwsh
@@ -183,49 +186,10 @@ jobs:
           name: vs
           path: editors/vs/Lens.VisualStudio/bin/Release/net472/Lens.VisualStudio-*.vsix
 
-  rider:
-    needs: prepare
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # net8.0 for the ReSharper backend, net10.0 for the language server that is bundled with the
-      # plugin
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      # Rider 2026.x is compiled for Java 25, and an older JDK cannot read the platform classes the
-      # plugin is compiled against
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 25
-
-      - uses: gradle/actions/setup-gradle@v4
-
-      - name: Stamp the version
-        shell: pwsh
-        run: ./build/Set-Version.ps1 -Version ${{ needs.prepare.outputs.version }}
-
-      # No riderPath is set on the runner, so the Rider SDK is downloaded - well over a gigabyte,
-      # which is why this leg is the slow one.
-      - name: Build the plugin
-        working-directory: editors/rider
-        run: ./gradlew buildPlugin --no-daemon
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: rider
-          path: editors/rider/build/distributions/*.zip
-
-  # Nothing leaves the run until all four artifacts exist, so a broken leg cannot spend a version
+  # Nothing leaves the run until every artifact exists, so a broken leg cannot spend a version
   # number or leave a release half populated.
   release:
-    needs: [prepare, nuget, vscode, vs, rider]
+    needs: [prepare, nuget, vscode, vs]
     if: needs.prepare.outputs.publish == 'true'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,275 @@
+name: Release
+
+# Run by hand from the Actions tab. Building a release is cheap and repeatable; putting one in
+# front of the public is not, so this workflow stops at a tagged GitHub release with every
+# artifact attached. Only NuGet is pushed automatically - the Visual Studio, VS Code and JetBrains
+# listings are updated by uploading the attached files by hand.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, for example 5.0.7. Leave empty to take the next unused number of the series in Directory.Build.props.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Build everything and attach it to the run, but create no tag, no release and push nothing to NuGet.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  # Decides which version this run produces, and refuses to start if that version has been
+  # released already. Every other job reads the answer from here, so all four artifacts carry the
+  # same number.
+  prepare:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      publish: ${{ steps.plan.outputs.publish }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the next number is derived from the existing tags, so the whole history is needed
+          fetch-depth: 0
+
+      - id: plan
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          version="$INPUT_VERSION"
+
+          if [ -z "$version" ]; then
+            series=$(sed -n 's:.*<VersionSeries>\(.*\)</VersionSeries>.*:\1:p' Directory.Build.props | head -1)
+
+            if [ -z "$series" ]; then
+              echo "::error::No <VersionSeries> was found in Directory.Build.props."
+              exit 1
+            fi
+
+            # The tags are the record of what exists, which is what makes the numbering
+            # restartable: bumping the series to 5.1 finds no 5.1.* tag and starts again at 5.1.0.
+            series_pattern=${series//./\\.}
+            highest=$(git tag --list "$series.*" | sed -n "s/^$series_pattern\.\([0-9][0-9]*\)$/\1/p" | sort -n | tail -1)
+
+            if [ -z "$highest" ]; then
+              version="$series.0"
+            else
+              version="$series.$((highest + 1))"
+            fi
+          fi
+
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::'$version' is not a three part version."
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+            echo "::error::Tag $version already exists, so that version has been released. Bump the series or pass a different version."
+            exit 1
+          fi
+
+          publish='true'
+          [ "$INPUT_DRY_RUN" != 'true' ] || publish='false'
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release $version"
+            echo
+            echo "- releasing: \`$publish\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Both packages are built at the same version, which also pins the LENS dependency that
+  # LENS.LanguageServer.Core takes on it.
+  nuget:
+    needs: prepare
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Pack
+        run: |
+          dotnet pack Lens/Lens.csproj --configuration Release -p:Version=${{ needs.prepare.outputs.version }} --output artifacts
+          dotnet pack Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj --configuration Release -p:Version=${{ needs.prepare.outputs.version }} --output artifacts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget
+          path: artifacts/*.nupkg
+
+  vscode:
+    needs: prepare
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Stamp the version
+        shell: pwsh
+        run: ./build/Set-Version.ps1 -Version ${{ needs.prepare.outputs.version }}
+
+      - name: Restore
+        working-directory: editors/vscode
+        run: npm ci
+
+      # "vsce package" runs the vscode:prepublish script, which publishes the language server into
+      # server\ and compiles the TypeScript, so no separate build step is needed here.
+      - name: Package
+        working-directory: editors/vscode
+        run: npx --no-install vsce package --out lens-lang-${{ needs.prepare.outputs.version }}.vsix
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vscode
+          path: editors/vscode/lens-lang-*.vsix
+
+  vs:
+    needs: prepare
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Stamp the version
+        shell: pwsh
+        run: ./build/Set-Version.ps1 -Version ${{ needs.prepare.outputs.version }}
+
+      # build.ps1 publishes the language server and then drives MSBuild, which it locates through
+      # vswhere - the same two steps a local build takes.
+      - name: Build the VSIX
+        shell: pwsh
+        run: ./editors/vs/build.ps1
+
+      # the built file has no version in its name, and all four artifacts end up side by side on
+      # the release page
+      - name: Name the VSIX after the version
+        shell: pwsh
+        run: |
+          Move-Item `
+            'editors/vs/Lens.VisualStudio/bin/Release/net472/Lens.VisualStudio.vsix' `
+            'editors/vs/Lens.VisualStudio/bin/Release/net472/Lens.VisualStudio-${{ needs.prepare.outputs.version }}.vsix'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vs
+          path: editors/vs/Lens.VisualStudio/bin/Release/net472/Lens.VisualStudio-*.vsix
+
+  rider:
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # net8.0 for the ReSharper backend, net10.0 for the language server that is bundled with the
+      # plugin
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      # Rider 2026.x is compiled for Java 25, and an older JDK cannot read the platform classes the
+      # plugin is compiled against
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Stamp the version
+        shell: pwsh
+        run: ./build/Set-Version.ps1 -Version ${{ needs.prepare.outputs.version }}
+
+      # No riderPath is set on the runner, so the Rider SDK is downloaded - well over a gigabyte,
+      # which is why this leg is the slow one.
+      - name: Build the plugin
+        working-directory: editors/rider
+        run: ./gradlew buildPlugin --no-daemon
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rider
+          path: editors/rider/build/distributions/*.zip
+
+  # Nothing leaves the run until all four artifacts exist, so a broken leg cannot spend a version
+  # number or leave a release half populated.
+  release:
+    needs: [prepare, nuget, vscode, vs, rider]
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      # NuGet trusted publishing exchanges this token for a short lived API key, which is why no
+      # NuGet secret exists in this repository
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Get a NuGet API key
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: impworks
+
+      - name: Publish to NuGet
+        run: |
+          dotnet nuget push 'artifacts/nuget/*.nupkg' \
+            --api-key '${{ steps.nuget-login.outputs.NUGET_API_KEY }}' \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      # The tag is written last: by this point every artifact is built and NuGet has accepted the
+      # packages, so the tag marks a version that really exists.
+      - name: Tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          gh release create "$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "$VERSION" \
+            --generate-notes \
+            $(find artifacts -type f | sort)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+    <PropertyGroup>
+        <!-- The single place the release series is written down. The patch number is assigned by
+             .github/workflows/release.yml, which reads this value and appends the next unused
+             patch; a local build gets ".0". Bump this to 5.1 to restart the numbering at 5.1.0. -->
+        <VersionSeries>5.0</VersionSeries>
+
+        <!-- Directory.Build.props is imported before the SDK fills in its own default, so an empty
+             value here means nothing on the command line set one. "dotnet pack -p:Version=x" still
+             wins, because Version takes precedence over VersionPrefix. -->
+        <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(VersionSeries).0</VersionPrefix>
+    </PropertyGroup>
+
+</Project>

--- a/Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj
+++ b/Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj
@@ -3,12 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Authors>LENS authors</Authors>
-        <PackageId>LENS.LanguageServer.Core</PackageId>
-        <Description>Editor-agnostic language services for LENS: documents, positions, completion, navigation and rename. Contains no protocol code, so an LSP server and an in-process editor plugin can share it.</Description>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/impworks/lens</PackageProjectUrl>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj
+++ b/Lens.LanguageServer.Core/Lens.LanguageServer.Core.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>5.0.0</Version>
         <Authors>LENS authors</Authors>
         <PackageId>LENS.LanguageServer.Core</PackageId>
         <Description>Editor-agnostic language services for LENS: documents, positions, completion, navigation and rename. Contains no protocol code, so an LSP server and an in-process editor plugin can share it.</Description>

--- a/Lens/Lens.csproj
+++ b/Lens/Lens.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>net47;netstandard2.0;net10.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>5.0.0</Version>
         <Authors>LENS authors</Authors>
         <PackageId>LENS</PackageId>
         <Description>Language for Embeddable .NET Scripting</Description>

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Stamps a version into every file that carries one by hand.
+
+.DESCRIPTION
+    The two NuGet projects take their version from Directory.Build.props, so they are not touched
+    here - a pack is given "-p:Version" instead. Everything else lives in a format MSBuild cannot
+    reach into: the VSIX manifest, the VS Code manifest and the Rider plugin properties. This
+    script is what the release workflow runs before it builds any of them.
+
+    The files are edited in place and are not meant to be committed: only the series in
+    Directory.Build.props is tracked, and the patch belongs to the release that produced it.
+
+.PARAMETER Version
+    The three-part version to write, for example 5.0.7.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string] $Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root = Resolve-Path (Join-Path $PSScriptRoot '..')
+
+# Read and write as UTF-8 without a BOM throughout, so that neither the umlauts nor anything else
+# non-ASCII in these files is mangled by a round trip.
+function Edit-File {
+    param(
+        [string] $Path,
+        [string] $Pattern,
+        [string] $Replacement
+    )
+
+    $full = Join-Path $root $Path
+
+    if (-not (Test-Path $full)) {
+        throw "$Path does not exist."
+    }
+
+    $text = [System.IO.File]::ReadAllText($full)
+
+    if ($text -notmatch $Pattern) {
+        throw "No version to replace was found in $Path - the pattern '$Pattern' did not match."
+    }
+
+    $updated = [regex]::Replace($text, $Pattern, $Replacement)
+    [System.IO.File]::WriteAllText($full, $updated, (New-Object System.Text.UTF8Encoding $false))
+
+    Write-Host "  $Path"
+}
+
+Write-Host "Stamping version $Version into:" -ForegroundColor Cyan
+
+# The VSIX manifest version is the one the Visual Studio Marketplace shows and orders releases by.
+Edit-File `
+    -Path 'editors/vs/Lens.VisualStudio/source.extension.vsixmanifest' `
+    -Pattern '(<Identity\b[^>]*?\bVersion=")[^"]*(")' `
+    -Replacement "`${1}$Version`${2}"
+
+# The VSIX assembly, kept in step with the manifest so a loaded extension reports the same version.
+Edit-File `
+    -Path 'editors/vs/Lens.VisualStudio/Lens.VisualStudio.csproj' `
+    -Pattern '(<Version>)[^<]*(</Version>)' `
+    -Replacement "`${1}$Version`${2}"
+
+# npm, and therefore vsce, take the version from here.
+Edit-File `
+    -Path 'editors/vscode/package.json' `
+    -Pattern '("version"\s*:\s*")[^"]*(")' `
+    -Replacement "`${1}$Version`${2}"
+
+# Not published by the workflow yet, but kept in step so a Rider release is a one-line change.
+Edit-File `
+    -Path 'editors/rider/gradle.properties' `
+    -Pattern '(?m)^(pluginVersion=).*$' `
+    -Replacement "`${1}$Version"

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -21,6 +21,7 @@ param(
     [string] $Version
 )
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $root = Resolve-Path (Join-Path $PSScriptRoot '..')

--- a/build/Set-Version.ps1
+++ b/build/Set-Version.ps1
@@ -72,7 +72,8 @@ Edit-File `
     -Pattern '("version"\s*:\s*")[^"]*(")' `
     -Replacement "`${1}$Version`${2}"
 
-# Not published by the workflow yet, but kept in step so a Rider release is a one-line change.
+# The Rider plugin is built locally rather than by the workflow, but its version is stamped from
+# the same place so that a release built by hand carries the same number as the rest.
 Edit-File `
     -Path 'editors/rider/gradle.properties' `
     -Pattern '(?m)^(pluginVersion=).*$' `

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,15 +1,19 @@
 How to publish a release
 ========================
 
-The `Release` workflow (`.github/workflows/release.yml`) builds all four
-artifacts, pushes the NuGet packages and leaves a tagged GitHub release with
-everything attached. It only ever runs when someone starts it from the Actions
-tab - not on a push, and not on a tag.
+The `Release` workflow (`.github/workflows/release.yml`) builds the artifacts,
+pushes the NuGet package and leaves a tagged GitHub release with everything
+attached. It only ever runs when someone starts it from the Actions tab - not on
+a push, and not on a tag.
 
 The marketplace listings are updated by hand, by downloading the files from the
 release and uploading them. Building a release is cheap and repeatable; putting
 one in front of the public is neither, and a marketplace upload cannot be taken
 back.
+
+The Rider plugin is the exception: it is not built by the workflow at all, and
+has to be built locally and attached to the release by hand - see
+[The Rider plugin](#the-rider-plugin).
 
 Versioning
 ----------
@@ -34,7 +38,7 @@ To restart the numbering, bump the series by hand:
 
 The next release then finds no `5.1.*` tag and produces `5.1.0`.
 
-A local build gets `<series>.0`, which is what the two NuGet projects use when
+A local build gets `<series>.0`, which is what the .NET projects use when
 nothing overrides them.
 
 Running a release
@@ -49,22 +53,40 @@ From the Actions tab, run `Release`. Both inputs are optional:
 
 A run builds, in parallel:
 
-* `LENS` and `LENS.LanguageServer.Core` NuGet packages
+* the `LENS` NuGet package
 * `lens-lang-<version>.vsix` for VS Code
 * `Lens.VisualStudio-<version>.vsix` for Visual Studio
-* `lens-rider-<version>.zip` for Rider
 
-The Rider leg is the slow one: no local Rider is pointed at on the runner, so
-the plugin is compiled against a downloaded SDK of well over a gigabyte.
-
-Only once all four have been built does the last job push to NuGet and create
+Only once all three have been built does the last job push to NuGet and create
 the release. A failure anywhere before that leaves nothing behind.
+
+The Rider plugin
+----------------
+
+It is not built by the workflow. Compiling against the Rider SDK costs a 3.6 GB
+download that unpacks to about 14 GB in the Gradle cache - past GitHub's 10 GB
+per-repository cache limit, so every run would pay for it again - and the result
+has to be uploaded to the JetBrains Marketplace by hand in any case.
+
+Everything else about it is intact: `build/Set-Version.ps1` still stamps
+`gradle.properties`, so a release build is
+
+```
+cd editors/rider
+gradlew.bat buildPlugin
+```
+
+after running `build/Set-Version.ps1 -Version <version>` from the repository
+root. The zip lands in `editors/rider/build/distributions/` and can be attached
+to the GitHub release by hand. See `editors/rider/README.md` for the build
+prerequisites.
 
 Where the version ends up
 -------------------------
 
-`LENS` and `LENS.LanguageServer.Core` are packed with `-p:Version`, which also
-pins the `LENS` dependency that `LENS.LanguageServer.Core` takes.
+`LENS` is packed with `-p:Version`. It is the only package that is published:
+`Lens.LanguageServer.Core` is marked `IsPackable=false`, because every consumer
+of it is in this repository and references the project directly.
 
 The other three manifests keep a version of their own, and
 `build/Set-Version.ps1` stamps them before their build. It edits the working
@@ -90,10 +112,6 @@ account's *Trusted Publishing* page. The policy names:
 * the repository, `impworks/lens`
 * the workflow file, `release.yml`
 
-A first release of a package that does not exist on nuget.org yet needs the
-policy to name the package as well, since there is no existing owner to check
-against.
-
 Publishing to the marketplaces
 ------------------------------
 
@@ -103,7 +121,7 @@ All three are manual, from the files attached to the GitHub release.
   <https://marketplace.visualstudio.com/manage/publishers/impworks>.
 * **VS Code** - upload `lens-lang-<version>.vsix` under the same publisher.
   The extension identifier is `impworks.lens-lang`.
-* **Rider** - upload `lens-rider-<version>.zip` at
-  <https://plugins.jetbrains.com/>. The first upload of a plugin has to be
-  manual in any case; JetBrains only accepts automated uploads for a plugin
-  that already exists there.
+* **Rider** - build the plugin locally as described above, then upload
+  `lens-rider-<version>.zip` at <https://plugins.jetbrains.com/>. The first
+  upload of a plugin has to be manual in any case; JetBrains only accepts
+  automated uploads for a plugin that already exists there.

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,16 +1,109 @@
-How to publish NuGet package
-============================
+How to publish a release
+========================
 
-First of all, clean and rebuild the project in Release configuration for Any CPU
-platform.
+The `Release` workflow (`.github/workflows/release.yml`) builds all four
+artifacts, pushes the NuGet packages and leaves a tagged GitHub release with
+everything attached. It only ever runs when someone starts it from the Actions
+tab - not on a push, and not on a tag.
 
-Then, execute the following in Visual Studio Command Prompt:
+The marketplace listings are updated by hand, by downloading the files from the
+release and uploading them. Building a release is cheap and repeatable; putting
+one in front of the public is neither, and a marketplace upload cannot be taken
+back.
 
-```console
-$ rem Note that script uses cmd syntax for the commands. If you use another
-$ rem shell, you may have to add some additional escaping to the commands.
-$ msbuild -m -p:Configuration=Release -p:Platform="Any CPU" -t:Clean;Rebuild
-$ nuget pack Lens\Lens.csproj -Properties Configuration=Release -Version 3.0.0-pre1
+Versioning
+----------
+
+`Directory.Build.props` holds the release series and nothing else:
+
+```xml
+<VersionSeries>5.0</VersionSeries>
 ```
 
-After that, publish `LENS.<version>.nupkg` file to NuGet.
+The number after it is not written down anywhere. The workflow looks at the
+tags that already exist, takes the highest one within the series and adds one;
+if the series has no tags yet, it starts at `.0`. The tag is created at the very
+end of the run, so a version number is never spent on a release that failed to
+build.
+
+To restart the numbering, bump the series by hand:
+
+```xml
+<VersionSeries>5.1</VersionSeries>
+```
+
+The next release then finds no `5.1.*` tag and produces `5.1.0`.
+
+A local build gets `<series>.0`, which is what the two NuGet projects use when
+nothing overrides them.
+
+Running a release
+-----------------
+
+From the Actions tab, run `Release`. Both inputs are optional:
+
+| Input     | Default           | Meaning                                                     |
+|-----------|-------------------|-------------------------------------------------------------|
+| `version` | next unused number | Release this exact version instead of the computed one.     |
+| `dry_run` | `false`           | Build everything and attach it to the run, but create no tag, no release, and push nothing. |
+
+A run builds, in parallel:
+
+* `LENS` and `LENS.LanguageServer.Core` NuGet packages
+* `lens-lang-<version>.vsix` for VS Code
+* `Lens.VisualStudio-<version>.vsix` for Visual Studio
+* `lens-rider-<version>.zip` for Rider
+
+The Rider leg is the slow one: no local Rider is pointed at on the runner, so
+the plugin is compiled against a downloaded SDK of well over a gigabyte.
+
+Only once all four have been built does the last job push to NuGet and create
+the release. A failure anywhere before that leaves nothing behind.
+
+Where the version ends up
+-------------------------
+
+`LENS` and `LENS.LanguageServer.Core` are packed with `-p:Version`, which also
+pins the `LENS` dependency that `LENS.LanguageServer.Core` takes.
+
+The other three manifests keep a version of their own, and
+`build/Set-Version.ps1` stamps them before their build. It edits the working
+tree only - nothing but the series is committed:
+
+* `editors/vs/Lens.VisualStudio/source.extension.vsixmanifest` and the VSIX
+  project file
+* `editors/vscode/package.json`
+* `editors/rider/gradle.properties`
+
+NuGet trusted publishing
+------------------------
+
+There is no NuGet API key in this repository. The workflow asks GitHub for an
+OIDC token and exchanges it for a short lived key through `NuGet/login@v1`,
+which is the approach nuget.org now recommends over long lived keys.
+
+This works only once a policy has been registered on nuget.org, under the
+account's *Trusted Publishing* page. The policy names:
+
+* the package owner - the `user` input of the `NuGet/login` step, currently
+  `impworks`, has to be that same nuget.org account
+* the repository, `impworks/lens`
+* the workflow file, `release.yml`
+
+A first release of a package that does not exist on nuget.org yet needs the
+policy to name the package as well, since there is no existing owner to check
+against.
+
+Publishing to the marketplaces
+------------------------------
+
+All three are manual, from the files attached to the GitHub release.
+
+* **Visual Studio** - upload `Lens.VisualStudio-<version>.vsix` at
+  <https://marketplace.visualstudio.com/manage/publishers/impworks>.
+* **VS Code** - upload `lens-lang-<version>.vsix` under the same publisher.
+  The extension identifier is `impworks.lens-lang`.
+* **Rider** - upload `lens-rider-<version>.zip` at
+  <https://plugins.jetbrains.com/>. The first upload of a plugin has to be
+  manual in any case; JetBrains only accepts automated uploads for a plugin
+  that already exists there.

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -63,10 +63,7 @@ the release. A failure anywhere before that leaves nothing behind.
 The Rider plugin
 ----------------
 
-It is not built by the workflow. Compiling against the Rider SDK costs a 3.6 GB
-download that unpacks to about 14 GB in the Gradle cache - past GitHub's 10 GB
-per-repository cache limit, so every run would pay for it again - and the result
-has to be uploaded to the JetBrains Marketplace by hand in any case.
+Currently not built by the pipeline - investigating the possible ways to avoid downloading the whole 14GB SDK.
 
 Everything else about it is intact: `build/Set-Version.ps1` still stamps
 `gradle.properties`, so a release build is

--- a/editors/rider/README.md
+++ b/editors/rider/README.md
@@ -47,16 +47,7 @@ breakpoints may go on a line, so the plugin has a second, .NET half - see
 
 ## Building
 
-The build has to compile against a Rider SDK. Pointing it at an installed Rider is much faster than
-letting Gradle download one (the Rider SDK archive is around 4 GB):
-
-```
-cd editors/rider
-gradlew.bat -PriderPath="C:/Program Files/JetBrains/JetBrains Rider 2026.2" buildPlugin
-```
-
-Without `-PriderPath`, the SDK named by `riderVersion` in `gradle.properties` is downloaded from the
-JetBrains repository instead.
+The build has to compile against a Rider SDK.
 
 If the JDK on `PATH` is older than the one the target Rider needs, point Gradle at Rider's own:
 

--- a/editors/rider/README.md
+++ b/editors/rider/README.md
@@ -29,11 +29,12 @@ breakpoints may go on a line, so the plugin has a second, .NET half - see
 
 ## Prerequisites
 
-* **JetBrains Rider 2025.2 or newer.** The plugin uses the IntelliJ Platform LSP API, which only
+* **JetBrains Rider 2026.1 or newer.** The plugin uses the IntelliJ Platform LSP API, which only
   exists in the paid IDEs, and a Rider extension point for the breakpoint gutter. It will not load
-  in IntelliJ IDEA Community or Android Studio.
-* **A JDK matching the Rider you build against**, to run Gradle. Rider 2026.x is compiled for Java
-  25; the JBR that ships inside Rider itself is a full JDK and works:
+  in IntelliJ IDEA Community or Android Studio. 2026.1 is the first release in which every LSP
+  feature the plugin relies on exists - see [Known gaps](#known-gaps-against-the-vs-code-extension).
+* **A JDK 25 or newer**, to run Gradle. Rider 2026.x is compiled for Java 25, so an older JDK
+  cannot read the platform classes; the JBR that ships inside Rider itself is a full JDK and works:
   `C:\Program Files\JetBrains\JetBrains Rider <version>\jbr`.
 * **.NET SDK 10** on `PATH`, to build the language server that gets bundled into the plugin. Pass
   `-PbundleServer=false` to skip it. The same `dotnet` builds the ReSharper backend half, which
@@ -51,7 +52,7 @@ letting Gradle download one (the Rider SDK archive is around 4 GB):
 
 ```
 cd editors/rider
-gradlew.bat -PriderPath="C:/Program Files/JetBrains/JetBrains Rider 2025.2" buildPlugin
+gradlew.bat -PriderPath="C:/Program Files/JetBrains/JetBrains Rider 2026.2" buildPlugin
 ```
 
 Without `-PriderPath`, the SDK named by `riderVersion` in `gradle.properties` is downloaded from the
@@ -60,7 +61,7 @@ JetBrains repository instead.
 If the JDK on `PATH` is older than the one the target Rider needs, point Gradle at Rider's own:
 
 ```
-set JAVA_HOME=C:\Program Files\JetBrains\JetBrains Rider 2025.2\jbr
+set JAVA_HOME=C:\Program Files\JetBrains\JetBrains Rider 2026.2\jbr
 ```
 
 The result is an installable zip:
@@ -105,7 +106,7 @@ language server's.
 `Lens.Rider.Backend.sln` can be opened on its own, but only after
 
 ```
-gradlew.bat -PriderPath="C:/Program Files/JetBrains/JetBrains Rider 2025.2" prepare
+gradlew.bat -PriderPath="C:/Program Files/JetBrains/JetBrains Rider 2026.2" prepare
 ```
 
 which writes `build/DotNetSdkPath.Generated.props` and `src/dotnet/nuget.config`. Without them the
@@ -191,12 +192,10 @@ the gutter.
   Enter keeps the previous indent.
 * **Interpolation holes are not coloured as code.** The lexer treats an interpolated string as one
   token; the server's semantic tokens still colour the names inside it.
-* **Rider version differences.** The platform gained LSP features over time: document symbols (the
-  file structure) arrived in 2025.3 and rename in 2026.1. On Rider 2025.2 those two are unavailable
-  however the plugin is written; everything else works from 2025.2 onwards.
-* The plugin uses the pre-2026.1 LSP API names (`LspServerSupportProvider`,
-  `ProjectWideLspServerDescriptor`) on purpose. They are deprecated in the newest platform but are
-  the only ones that exist on the older Riders this plugin still supports.
+* The plugin still uses the pre-2026.1 LSP API names (`LspServerSupportProvider`,
+  `ProjectWideLspServerDescriptor`), which are deprecated in the current platform. They were the
+  only ones available while Rider 2025.2 was supported; now that `since-build` is 261 they can be
+  replaced with the current API, and that has not been done yet.
 * **The backend half has no automated tests.** `test` covers the lexer and the PSI on the JVM only;
   the backend is exercised by hand in `runIde`. A ReSharper test harness would be a bigger addition
   than the six small components it would be testing.

--- a/editors/rider/build.gradle.kts
+++ b/editors/rider/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 import kotlin.io.path.absolute
@@ -48,25 +47,9 @@ tasks.test {
     useJUnit()
 }
 
-// The newest Rider runs on Java 25, but a plugin compiled for it cannot be loaded by the 2025.x
-// releases this one still supports, so the bytecode is held at the level "sinceBuild" implies. The
-// IntelliJ Platform plugin raises both targets to whatever the platform being compiled against
-// uses, and does so late, which is why the values are put back afterwards.
-afterEvaluate {
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
-    }
-
-    java {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
-
-    tasks.withType<JavaCompile>().configureEach {
-        sourceCompatibility = JavaVersion.VERSION_21.toString()
-        targetCompatibility = JavaVersion.VERSION_21.toString()
-    }
-}
+// Every Rider from 2026.1 on runs on Java 25, so the bytecode level the IntelliJ Platform plugin
+// derives from the platform being compiled against is loadable everywhere "sinceBuild" allows.
+// Nothing has to be pinned back.
 
 intellijPlatform {
     pluginConfiguration {

--- a/editors/rider/gradle.properties
+++ b/editors/rider/gradle.properties
@@ -3,11 +3,6 @@ pluginVersion=5.0.0
 # The Rider build the plugin is compiled against when no local installation is pointed at.
 riderVersion=2026.2
 
-# 2026.1 is the first Rider in which every LSP feature the plugin uses exists: the platform gained
-# document symbols in 2025.3 and rename in 2026.1. Supporting anything older would mean shipping a
-# plugin that silently does less on the older builds.
-sinceBuild=261
-
 # Compiling against a local Rider avoids downloading the SDK. Point this at an installation
 # directory, for example:
 #   riderPath=C:/Program Files/JetBrains/JetBrains Rider 2026.2

--- a/editors/rider/gradle.properties
+++ b/editors/rider/gradle.properties
@@ -3,9 +3,10 @@ pluginVersion=5.0.0
 # The Rider build the plugin is compiled against when no local installation is pointed at.
 riderVersion=2026.2
 
-# 2025.2 is the first Rider that exposes the LSP API through com.intellij.modules.lsp. Two of the
-# features degrade below the newest builds - see the README.
-sinceBuild=252
+# 2026.1 is the first Rider in which every LSP feature the plugin uses exists: the platform gained
+# document symbols in 2025.3 and rename in 2026.1. Supporting anything older would mean shipping a
+# plugin that silently does less on the older builds.
+sinceBuild=261
 
 # Compiling against a local Rider avoids downloading the SDK. Point this at an installation
 # directory, for example:

--- a/editors/vs/Lens.VisualStudio/source.extension.vsixmanifest
+++ b/editors/vs/Lens.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Lens.VisualStudio.8f2c1d4e-6b7a-4f31-9c05-7d2a5e1b93af" Version="5.0.0" Language="en-US" Publisher="LENS authors" />
+        <Identity Id="Lens.VisualStudio.8f2c1d4e-6b7a-4f31-9c05-7d2a5e1b93af" Version="5.0.0" Language="en-US" Publisher="impworks" />
         <DisplayName>LENS</DisplayName>
         <Description xml:space="preserve">Language support for LENS, the embeddable .NET scripting language: highlighting, completion, diagnostics, navigation and rename for .lns files.</Description>
         <License>LICENSE.md</License>

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -5,5 +5,6 @@ src/**
 scripts/**
 out/**/*.map
 tsconfig.json
+samples/**
 **/*.ts
 !server/**

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
     "displayName": "LENS",
     "description": "Language support for LENS: highlighting, completion, diagnostics, navigation and rename.",
     "version": "5.0.0",
-    "publisher": "lens",
+    "publisher": "impworks",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The new Github action does the following:

* Finds the last `5.0.x` version tag, increments by 1 (or defaults to 5.0.0 for first run)
* Creates the NuGet package
* Creates a VS Code plugin
* Creates a VS plugin
* If not `dry_run`:
    * Pushes the NuGet package to the repo using "Trusted publishing"
    * Creates a Github release with all artifacts attached to it

Current limitations:

* No automatic pushes to VS / VS Code marketplaces. Not sure how to do that - Claude requests a PAT from Azure DevOps (?) which seems to be paid. Maybe I need to push the first version manually and then I get some kind of credentials for automatic update
* No Rider plugin built. It appears that we need a 3.4GB SDK download which expands to 14GB - does not fit onto the 10GB disk for a Github runner. There is likely a better approach, but let's tacke it in a follow-up PR.